### PR TITLE
Create React-Router-v4-withTracker(wrapper)

### DIFF
--- a/src/example/React-Router-v4-withTracker(wrapper)
+++ b/src/example/React-Router-v4-withTracker(wrapper)
@@ -1,0 +1,67 @@
+
+
+/**
+ * Originally from ReactGA Community Wiki Page https://github.com/react-ga/react-ga/wiki/React-Router-v4-withTracker (Implemented for ga-4-react by Cristian Custodio)
+ */
+ 
+ //Create a new file called withTracker.jsx and insert your ga-code
+import React, { Component } from "react";
+import GA4React from "ga-4-react";
+
+const ga4react = new GA4React("INSERT GA-CODE HERE");
+
+export default function withTracker(WrappedComponent) {
+  const trackPage = (page) => {
+    ga4react.initialize().then(
+      (ga4) => {
+        ga4.pageview(page);
+        ga4.gtag("event", "pageview", "path"); // or your custom gtag event
+      },
+      (err) => {
+        console.error(err);
+      }
+    );
+  };
+
+  const HOC = class extends Component {
+    componentDidMount() {
+      const page = this.props.location.pathname;
+      trackPage(page);
+    }
+
+    componentWillReceiveProps(nextProps) {
+      const currentPage = this.props.location.pathname;
+      const nextPage = nextProps.location.pathname;
+
+      if (currentPage !== nextPage) {
+        trackPage(nextPage);
+      }
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} />;
+    }
+  };
+
+  return HOC;
+}
+
+
+//Implement in react-router page
+import React from "react";
+import { Route, Switch } from "react-router-dom";
+import Home from "../Pages/Home";
+import NotFound from "../Pages/NotFound";
+import withTracker from "./withTracker"; //Import withTracker page from code above
+
+
+class Routes extends React.Component {
+  render() {
+    return (
+      <Switch>
+        <Route exact path="/" component={withTracker(Home)} />
+        <Route component={withTracker(NotFound)} />
+      </Switch>
+    );
+  }
+}


### PR DESCRIPTION
Wrapper component for React-Router Pages, add google analytics version 4 by using the wrapper on the page name in each route eg.. withTracker(home).