### PR TITLE
Check the page status before waiting for readystatechange

### DIFF
--- a/src/lib/ga4manager.tsx
+++ b/src/lib/ga4manager.tsx
@@ -172,7 +172,11 @@ export class GA4React implements GA4ReactInterface {
         }
       };
 
-      document.addEventListener('readystatechange', onChangeReadyState);
+      if (document.readyState !== 'complete') {
+        document.addEventListener('readystatechange', onChangeReadyState);
+      } else {
+        onChangeReadyState();
+      }
 
       setTimeout(() => {
         reject(new Error('GA4React Timeout'));


### PR DESCRIPTION
This is a continuation of #3. If a component is added to the page which pulls in `ga-4-react`, and that happens after `document.readyState === 'complete'`, the current code won't do anything. This PR fixes that by first verifying `readyState` to determine whether it's appropriate to listen for changes. If not, it'll inject the script tag immediately instead.